### PR TITLE
Fix warning when running from pytest

### DIFF
--- a/aiosolr.py
+++ b/aiosolr.py
@@ -33,7 +33,8 @@ class Solr():
 
     def __del__(self):
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.session.close())
+        if loop and self.session:
+            loop.run_until_complete(self.session.close())
 
     def _get_collection(self, kwargs):
         """Get the collection name from the kwargs or instance variable."""

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 if sys.version_info < (3, 6):
     sys.exit('Sorry, Python < 3.6 is not supported')
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 
 setup(
     name="aiosolr",


### PR DESCRIPTION
Exception ignored in: <function Solr.__del__ at 0x10745e9e0>
Traceback (most recent call last):
  File "/Users/bradley.belyeu/.pyenv/versions/3.7.4/envs/search/lib/python3.7/site-packages/aiosolr.py", line 35, in __del__
TypeError: 'NoneType' object is not callable
Exception ignored in: <function ClientSession.__del__ at 0x106004950>
Traceback (most recent call last):
  File "/Users/bradley.belyeu/.pyenv/versions/3.7.4/envs/search/lib/python3.7/site-packages/aiohttp/client.py", line 227, in __del__
TypeError: 'NoneType' object is not callable